### PR TITLE
Fixed translation issue with "udgiv" in templates

### DIFF
--- a/angular-src/src/app/features/template-manager/template-editor/template-editor.component.html
+++ b/angular-src/src/app/features/template-manager/template-editor/template-editor.component.html
@@ -41,7 +41,7 @@
     </button>
     <button *ngIf="!readonly && template?.id" type="button" (click)="openFinalizeModal()"
       class="px-4 py-2 bg-purple-500 text-white rounded-lg shadow-sm hover:bg-purple-600 focus:ring-2 focus:ring-purple-400 focus:outline-none">
-      Udgiv
+      {{ 'TMP_PUBLISH' | translate }}
     </button>
   </div>
 </form>

--- a/angular-src/src/assets/i18n/da.json
+++ b/angular-src/src/assets/i18n/da.json
@@ -67,6 +67,7 @@
   "TMP_FINALIZE_TITLE": "Udgiv skabelon?",
   "TMP_FINALIZE_TEXT": "Når en skabelon udgives, bliver den skrivebeskyttet. <br/>Er du sikker på, at du vil udgive?",
   "TMP_FINALIZE_CONFIRM": "Udgiv",
+  "TMP_PUBLISH": "Udgiv",
   "TMP_VIEW_MODE": "Skabelonvisning",
   "TMP_EDIT_MODE": "Skabelonredigering",
 

--- a/angular-src/src/assets/i18n/en.json
+++ b/angular-src/src/assets/i18n/en.json
@@ -68,6 +68,7 @@
   "TMP_FINALIZE_TITLE": "Publish template?",
   "TMP_FINALIZE_TEXT": "When a template is published, it becomes read-only. <br/>Are you sure you want to publish?",
   "TMP_FINALIZE_CONFIRM": "Publish",
+  "TMP_PUBLISH": "Publish",
   "TMP_VIEW_MODE": "Template View",
   "TMP_EDIT_MODE": "Template Editing",
 


### PR DESCRIPTION
"udgiv" is now "Publish" for template editor page