### PR TITLE
Fix Template name already exists error

### DIFF
--- a/Backend/API/Controllers/QuestionnaireTemplateController.cs
+++ b/Backend/API/Controllers/QuestionnaireTemplateController.cs
@@ -85,9 +85,9 @@ namespace API.Controllers
                 template = await _questionnaireTemplateService.AddTemplate(questionnaireTemplate);
 
             }
-            catch (SQLException.ItemAlreadyExists)
+            catch (SQLException.ItemAlreadyExists ex)
             {
-                return Conflict();
+                return Conflict(ex.Message);
             }
 
             return CreatedAtRoute("", template.Id, template);
@@ -157,6 +157,10 @@ namespace API.Controllers
             catch (SQLException.ItemNotFound)
             {
                 return NotFound();
+            }
+            catch (SQLException.ItemAlreadyExists ex)
+            {
+                return Conflict(ex.Message);
             }
             catch (SQLException.NotValidated)
             {

--- a/angular-src/src/app/features/template-manager/template-manager.component.html
+++ b/angular-src/src/app/features/template-manager/template-manager.component.html
@@ -58,14 +58,8 @@
             <app-loading></app-loading>
           </div>
         }
-        <!-- Error Message -->
-        @if (errorMessage) {
-          <div class="text-center p-4">
-            <p class="text-red-500 font-semibold text-lg">{{ errorMessage | translate }}</p>
-          </div>
-        }
         <!-- Template List -->
-        @if (!isLoading && !errorMessage) {
+        @if (!isLoading) {
           <ul class="space-y-4 mt-4">
             @for (template of templateBases; track template) {
               <li
@@ -105,7 +99,7 @@
           </ul>
         }
         <!-- Pagination -->
-        @if (!isLoading && !errorMessage) {
+        @if (!isLoading) {
           <app-pagination
             [currentPage]="currentPage"
             [totalPages]="totalPages"
@@ -131,6 +125,7 @@
         [text]="modalText"
         [confirmText]="confirmText"
         [cancelText]="cancelText"
+        [showCancelButton]="showCancelButton"
         (confirm)="onModalConfirm()"
         (cancel)="onModalCancel()">
       </app-modal>

--- a/angular-src/src/app/features/template-manager/template-manager.component.ts
+++ b/angular-src/src/app/features/template-manager/template-manager.component.ts
@@ -16,7 +16,8 @@ import { ModalComponent } from '../../shared/components/modal/modal.component';
 enum TemplateModalType {
   None = 'none',
   Delete = 'delete',
-  Copy = 'copy'
+  Copy = 'copy',
+  Error = 'error'
 }
 
 /**
@@ -68,7 +69,6 @@ export class TemplateManagerComponent {
   pageSizeOptions: number[] = [5, 10, 15, 20];
 
   isLoading = false;
-  errorMessage: string | null = null;
   private searchSubject = new Subject<string>();
   TemplateModalType = TemplateModalType;
 
@@ -82,6 +82,7 @@ export class TemplateManagerComponent {
   activeModalType: TemplateModalType = TemplateModalType.None;
   activeModalTemplateId: string | null = null;
   deleteConfirmStep = 0;
+  modalErrorMessage: string = '';
 
  /**
  * Wire up debounced search and load the first page.
@@ -139,7 +140,6 @@ export class TemplateManagerComponent {
   /** Fetch a page of template bases. */
   private fetchTemplateBases(): void {
     this.isLoading = true;
-    this.errorMessage = null;
     const nextCursor = this.cachedCursors[this.currentPage] ?? undefined;
     this.templateService
       .getTemplateBases(this.pageSize, nextCursor, this.searchTerm, this.searchType)
@@ -159,7 +159,8 @@ export class TemplateManagerComponent {
         },
         error: (err) => {
           console.error('Error fetching templates:', err);
-          this.errorMessage = 'TMP_FAIL_LOAD_LIST';
+          this.modalErrorMessage = 'TMP_FAIL_LOAD_LIST';
+          this.showModal(TemplateModalType.Error);
         },
       });
   }
@@ -195,7 +196,8 @@ selectTemplate(id: string): void {
       },
       error: err => {
         console.error('Error fetching template:', err);
-        this.errorMessage = 'TMP_FAIL_LOAD_LIST';
+        this.modalErrorMessage = 'TMP_FAIL_LOAD_DETAIL';
+        this.showModal(TemplateModalType.Error);
       }
     });
 }
@@ -276,9 +278,10 @@ openDeleteModal(templateId: string): void {
           this.resetData();
           this.fetchTemplateBases();
         },
-        error: () => {
-          console.error('Error adding template');
+        error: (err) => {
+          console.error('Error adding template:', err);
           updatedTemplate.id = undefined;
+          this.handleSaveError(err);
         },
       });
     } else {
@@ -288,9 +291,29 @@ openDeleteModal(templateId: string): void {
           this.selectedTemplate = null;
           this.fetchTemplateBases();
         },
-        error: (err) => console.error('Error updating template:', err),
+        error: (err) => {
+          console.error('Error updating template:', err);
+          this.handleSaveError(err);
+        },
       });
     }
+  }
+
+  private handleSaveError(err: any): void {
+    let errorKey: string;
+    if (err.status === 409) {
+      // Conflict - duplicate title - always show user-friendly message
+      errorKey = 'TMP_ERROR_DUPLICATE_TITLE';
+    } else if (err.status === 400) {
+      // Bad request - validation error
+      errorKey = 'TMP_ERROR_VALIDATION';
+    } else {
+      // General error
+      errorKey = 'TMP_ERROR_SAVE';
+    }
+    
+    this.modalErrorMessage = errorKey;
+    this.showModal(TemplateModalType.Error);
   }
 
   onCancelEdit(): void {
@@ -309,11 +332,24 @@ hideModal() {
   this.activeModalType = TemplateModalType.None;
   this.activeModalTemplateId = null;
   this.deleteConfirmStep = 0;
+  this.modalErrorMessage = '';
 }
 
 /** True when any modal is visible (used by <app-modal>). */
 get isModalOpen(): boolean { 
   return this.activeModalType !== TemplateModalType.None; 
+}
+
+/** Whether to show cancel button based on modal type. */
+get showCancelButton(): boolean {
+  switch (this.activeModalType) {
+    case TemplateModalType.Error:
+      return false;
+    case TemplateModalType.Delete:
+    case TemplateModalType.Copy:
+    default:
+      return true;
+  }
 }
 
 /** Title text resolved from i18n depending on modal type/step. */
@@ -325,6 +361,8 @@ get modalTitle(): string {
         : this.translate.instant('TMP_DELETE_CONFIRM_WARN');
     case TemplateModalType.Copy:
       return this.translate.instant('TMP_COPY_TITLE');
+    case TemplateModalType.Error:
+      return this.translate.instant('TMP_ERROR_TITLE');
     default:
       return '';
   }
@@ -338,6 +376,8 @@ get modalText(): string {
         : this.translate.instant('TMP_DELETE_FINAL_WARN_MSG');
     case TemplateModalType.Copy:
       return this.translate.instant('TMP_COPY_MSG');
+    case TemplateModalType.Error:
+      return this.translate.instant(this.modalErrorMessage);
     default:
       return '';
   }
@@ -352,6 +392,8 @@ get confirmText(): string {
         : this.translate.instant('TMP_DELETE');
     case TemplateModalType.Copy:
       return this.translate.instant('COMMON.BUTTONS.COPY');
+    case TemplateModalType.Error:
+      return this.translate.instant('COMMON.BUTTONS.CLOSE');
     default:
       return this.translate.instant('COMMON.BUTTONS.CLOSE');
   }
@@ -361,10 +403,10 @@ get confirmText(): string {
 get cancelText(): string {
   switch (this.activeModalType) {
     case TemplateModalType.Delete:
-      return this.translate.instant('COMMON.BUTTONS.CANCEL');
     case TemplateModalType.Copy:
+      return this.translate.instant('COMMON.BUTTONS.CANCEL');
     default:
-      return this.translate.instant('COMMON.BUTTONS.CLOSE');       // already in your JSON
+      return this.translate.instant('COMMON.BUTTONS.CLOSE');
   }
 }
 
@@ -372,8 +414,14 @@ get cancelText(): string {
  * confirm handler:
  * - Delete: two-step confirm; on final confirm calls delete API.
  * - Copy: loads source template, deep-copies it into a new local draft and opens editor.
+ * - Error: simply closes the modal.
  */
 onModalConfirm(): void {
+  if (this.activeModalType === TemplateModalType.Error) {
+    this.hideModal();
+    return;
+  }
+
   const id = this.activeModalTemplateId ?? undefined;
   if (!id) return;
 

--- a/angular-src/src/app/shared/components/modal/modal.component.html
+++ b/angular-src/src/app/shared/components/modal/modal.component.html
@@ -4,11 +4,13 @@
       <h3 class="text-lg font-semibold mb-4">{{ title }}</h3>
       <p class="mb-6" [innerHTML]="text"></p>
       <div class="flex justify-end gap-2">
-        <button
-          (click)="onCancel()"
-          class="px-4 py-2 bg-gray-300 text-gray-800 rounded hover:bg-gray-400 focus:outline-none">
-          {{ cancelText }}
-        </button>
+        @if (showCancelButton && cancelText) {
+          <button
+            (click)="onCancel()"
+            class="px-4 py-2 bg-gray-300 text-gray-800 rounded hover:bg-gray-400 focus:outline-none">
+            {{ cancelText }}
+          </button>
+        }
         <button
           (click)="onConfirm()"
           class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 focus:outline-none">

--- a/angular-src/src/app/shared/components/modal/modal.component.ts
+++ b/angular-src/src/app/shared/components/modal/modal.component.ts
@@ -46,6 +46,9 @@ export class ModalComponent {
   /** Label for the cancel button. */
   @Input() cancelText: string = 'No';
 
+  /** Whether to show the cancel button. */
+  @Input() showCancelButton: boolean = true;
+
   /** Emits when the user confirms the action. */
   @Output() confirm = new EventEmitter<void>();
 

--- a/angular-src/src/assets/i18n/da.json
+++ b/angular-src/src/assets/i18n/da.json
@@ -30,6 +30,10 @@
   "TMP_FAIL_LOAD_DETAIL": "Indlæsning af skabelondetaljer mislykkedes.",
   "TMP_DELETE_ERROR": "Fejl ved sletning af skabelon.",
   "TMP_UPDATE_ERROR": "Fejl ved opdatering af skabelon.",
+  "TMP_ERROR_TITLE": "Fejl",
+  "TMP_ERROR_DUPLICATE_TITLE": "En skabelon med dette navn eksisterer allerede. Vælg venligst et andet navn.",
+  "TMP_ERROR_VALIDATION": "Valideringsfejl. Kontroller venligst dine indtastninger.",
+  "TMP_ERROR_SAVE": "Fejl ved gemning af skabelon. Prøv igen.",
   "TMP_NO_ACTIVE_QUESTIONNAIRES": "Der er ingen aktive spørgeskemaer",
 
   "TMP_EDITOR_TITLE": "Skabelonredigering",

--- a/angular-src/src/assets/i18n/en.json
+++ b/angular-src/src/assets/i18n/en.json
@@ -30,6 +30,10 @@
   "TMP_FAIL_LOAD_DETAIL": "Failed to load the full template details.",
   "TMP_DELETE_ERROR": "Error deleting template.",
   "TMP_UPDATE_ERROR": "Error updating template.",
+  "TMP_ERROR_TITLE": "Error",
+  "TMP_ERROR_DUPLICATE_TITLE": "A template with this name already exists. Please choose a different name.",
+  "TMP_ERROR_VALIDATION": "Validation error. Please check your inputs.",
+  "TMP_ERROR_SAVE": "Error saving template. Please try again.",
   "TMP_NO_ACTIVE_QUESTIONNAIRES": "There are no active questionnaires",
 
   "TMP_EDITOR_TITLE": "Template Editing",


### PR DESCRIPTION
Adds detailed error handling for duplicate template titles and validation errors in both backend and frontend. Backend now returns conflict messages for unique constraint violations for **questionaire template**. Frontend displays user-friendly error modals for save, load, and validation errors, and updates modal and i18n logic to support these cases.