### PR TITLE
Add version entry handling in settings file if missing

### DIFF
--- a/Backend/API/Utils/SettingsHelper.cs
+++ b/Backend/API/Utils/SettingsHelper.cs
@@ -53,6 +53,15 @@ public class SettingsHelper(string settingsFile)
     {
         RootSettings currentSettings = JsonSerializer.Deserialize<RootSettings>(Read(_settingsFile), _jsonSerializerOptions) ?? throw new InvalidOperationException("Failed to deserialize settings file.");
         RootSettings defaultSettings = new();
+
+        using JsonDocument doc = JsonDocument.Parse(Read(_settingsFile));
+        JsonElement root = doc.RootElement;
+
+        if (!root.TryGetProperty("Version", out JsonElement versionElement))
+        {
+            currentSettings.Version = 0;
+        }
+
         if (currentSettings.Version == defaultSettings.Version)
         {
             return;


### PR DESCRIPTION
This pull request updates the `CheckSettingsVersion` method to improve how the settings version is handled when the `Version` property is missing from the settings file. Now, if the `Version` property is absent, it explicitly sets the version to `0` before proceeding with the version check.

Settings version handling improvement:

* Updated `CheckSettingsVersion` in `SettingsHelper.cs` to parse the settings file as JSON, check for the presence of the `Version` property, and set `currentSettings.Version` to `0` if it's missing.

Closes #100 